### PR TITLE
feat(logging): emit aggregate-safe SAML IdP events

### DIFF
--- a/internal/authentication/handler.go
+++ b/internal/authentication/handler.go
@@ -201,10 +201,6 @@ func (h *AuthHandler) ACS(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 
-	h.logger().Info("saml authentication successful",
-		zap.String("subject", result.Subject),
-		zap.String("idp_entity_id", result.IdPEntityID),
-	)
 	h.metricsRecorder().RecordAuthAttempt(result.IdPEntityID, true)
 	h.metricsRecorder().RecordAuthSuccess(result.IdPEntityID)
 	h.metricsRecorder().RecordAuthDuration(result.IdPEntityID, "success", duration)
@@ -259,6 +255,7 @@ func (h *AuthHandler) ACS(w http.ResponseWriter, r *http.Request) error {
 		h.onError(w, r, domain.ServiceError("Failed to create session"))
 		return err
 	}
+	h.logAuthenticationSuccess(idp, duration)
 	h.metricsRecorder().RecordSessionCreated()
 
 	// Delegate cookie writing and redirect to the caller.
@@ -266,6 +263,32 @@ func (h *AuthHandler) ACS(w http.ResponseWriter, r *http.Request) error {
 		h.OnAuthenticated(w, r, token, session)
 	}
 	return nil
+}
+
+// @tra: Adapter.SAMLOrgEntryLogging
+func authAggregateLogFields(event, authFlow string, idp *domain.IdPInfo) []zap.Field {
+	fields := []zap.Field{
+		zap.String("event", event),
+		zap.String("auth_flow", authFlow),
+	}
+	if idp == nil {
+		return fields
+	}
+
+	fields = append(fields, zap.String("idp_entity_id", idp.EntityID))
+	if idp.DisplayName != "" {
+		fields = append(fields, zap.String("idp_display_name", idp.DisplayName))
+	}
+	if idp.RegistrationAuthority != "" {
+		fields = append(fields, zap.String("idp_registration_authority", idp.RegistrationAuthority))
+	}
+	return fields
+}
+
+func (h *AuthHandler) logAuthenticationSuccess(idp *domain.IdPInfo, duration time.Duration) {
+	fields := authAggregateLogFields("saml_disco_session_created", "saml", idp)
+	fields = append(fields, zap.Duration("duration", duration))
+	h.logger().Info("saml authentication successful", fields...)
 }
 
 // resolveACSURL returns the configured ACS URL or derives it from the request.
@@ -326,10 +349,10 @@ func (h *AuthHandler) onDenied(w http.ResponseWriter, r *http.Request, subject s
 // noopMetricsRecorder satisfies ports.MetricsRecorder with no-op methods.
 type noopMetricsRecorder struct{}
 
-func (n *noopMetricsRecorder) RecordAuthAttempt(string, bool)              {}
-func (n *noopMetricsRecorder) RecordAuthSuccess(string)                    {}
-func (n *noopMetricsRecorder) RecordAuthFailure(string, string)            {}
+func (n *noopMetricsRecorder) RecordAuthAttempt(string, bool)                   {}
+func (n *noopMetricsRecorder) RecordAuthSuccess(string)                         {}
+func (n *noopMetricsRecorder) RecordAuthFailure(string, string)                 {}
 func (n *noopMetricsRecorder) RecordAuthDuration(string, string, time.Duration) {}
-func (n *noopMetricsRecorder) RecordSessionCreated()                       {}
-func (n *noopMetricsRecorder) RecordSessionValidation(bool)                {}
-func (n *noopMetricsRecorder) RecordMetadataRefresh(string, bool, int)     {}
+func (n *noopMetricsRecorder) RecordSessionCreated()                            {}
+func (n *noopMetricsRecorder) RecordSessionValidation(bool)                     {}
+func (n *noopMetricsRecorder) RecordMetadataRefresh(string, bool, int)          {}

--- a/internal/authentication/structured_logging_test.go
+++ b/internal/authentication/structured_logging_test.go
@@ -1,0 +1,55 @@
+//go:build unit
+
+package authentication
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/philiph/caddy-saml-disco/internal/domain"
+	"github.com/philiph/caddy-saml-disco/internal/testutil/tra"
+)
+
+func TestLogAuthenticationSuccessLogsAggregateSafeSessionEvent(t *testing.T) {
+	tra.Require(t, "Adapter.SAMLOrgEntryLogging")
+
+	core, logs := observer.New(zap.InfoLevel)
+	h := &AuthHandler{Logger: zap.New(core)}
+	idp := &domain.IdPInfo{
+		EntityID:              "https://idp.example.edu/idp/shibboleth",
+		DisplayName:           "Example University",
+		RegistrationAuthority: "https://federation.example.org",
+	}
+
+	h.logAuthenticationSuccess(idp, 37*time.Millisecond)
+
+	entries := logs.FilterMessage("saml authentication successful").All()
+	if len(entries) != 1 {
+		t.Fatalf("saml authentication successful logs = %d, want 1", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	t.Logf("observed aggregate session log fields: %#v", fields)
+	assertAuthField(t, fields, "event", "saml_disco_session_created")
+	assertAuthField(t, fields, "auth_flow", "saml")
+	assertAuthField(t, fields, "idp_entity_id", "https://idp.example.edu/idp/shibboleth")
+	assertAuthField(t, fields, "idp_display_name", "Example University")
+	assertAuthField(t, fields, "idp_registration_authority", "https://federation.example.org")
+	assertAuthAbsentField(t, fields, "subject")
+}
+
+func assertAuthField(t *testing.T, fields map[string]interface{}, key string, want interface{}) {
+	t.Helper()
+	if got := fields[key]; got != want {
+		t.Fatalf("field %s = %#v, want %#v (all fields: %#v)", key, got, want, fields)
+	}
+}
+
+func assertAuthAbsentField(t *testing.T, fields map[string]interface{}, key string) {
+	t.Helper()
+	if _, ok := fields[key]; ok {
+		t.Fatalf("field %s should be absent (all fields: %#v)", key, fields)
+	}
+}

--- a/internal/discovery/handlers.go
+++ b/internal/discovery/handlers.go
@@ -112,10 +112,6 @@ func (h *DiscoveryHandler) HandleSelectIdP(w http.ResponseWriter, r *http.Reques
 		return nil
 	}
 
-	h.getLogger().Info("idp selected for authentication",
-		zap.String("entity_id", req.EntityID),
-	)
-
 	if req.Remember {
 		h.setRememberIdPCookie(w, r, req.EntityID)
 	}
@@ -128,6 +124,7 @@ func (h *DiscoveryHandler) HandleSelectIdP(w http.ResponseWriter, r *http.Reques
 		h.renderAppError(w, r, domain.ConfigError("SAML service is not configured"))
 		return nil
 	}
+	h.logIdPSelected(idp, "api_select", zap.Bool("remember_idp", req.Remember))
 
 	relayState := req.ReturnURL
 	if relayState == "" {
@@ -145,6 +142,7 @@ func (h *DiscoveryHandler) HandleSelectIdP(w http.ResponseWriter, r *http.Reques
 		h.renderAppError(w, r, domain.AuthError("Failed to start authentication", err))
 		return nil
 	}
+	h.logSAMLLoginStarted(idp, "api_select", opts.ForceAuthn, zap.Bool("remember_idp", req.Remember))
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]string{
@@ -199,6 +197,7 @@ func (h *DiscoveryHandler) HandleDiscoveryUI(w http.ResponseWriter, r *http.Requ
 				h.renderAppError(w, r, domain.AuthError("Failed to start authentication", err))
 				return nil
 			}
+			h.logSAMLLoginStarted(idp, "single_idp_discovery", opts.ForceAuthn)
 			http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 			return nil
 		}
@@ -273,6 +272,7 @@ func (h *DiscoveryHandler) HandleRedirectToIdP(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	h.logSAMLLoginStarted(idp, "protected_route", opts.ForceAuthn)
 	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 }
 
@@ -284,6 +284,47 @@ func (h *DiscoveryHandler) isBypassIdP(entityID string) bool {
 		}
 	}
 	return false
+}
+
+// @tra: Adapter.SAMLOrgEntryLogging
+func idpAggregateLogFields(event, authFlow string, idp *domain.IdPInfo) []zap.Field {
+	fields := []zap.Field{
+		zap.String("event", event),
+		zap.String("auth_flow", authFlow),
+	}
+	if idp == nil {
+		return fields
+	}
+
+	fields = append(fields, zap.String("idp_entity_id", idp.EntityID))
+	if idp.DisplayName != "" {
+		fields = append(fields, zap.String("idp_display_name", idp.DisplayName))
+	}
+	if idp.RegistrationAuthority != "" {
+		fields = append(fields, zap.String("idp_registration_authority", idp.RegistrationAuthority))
+	}
+	return fields
+}
+
+func (h *DiscoveryHandler) logSAMLLoginStarted(idp *domain.IdPInfo, entryPoint string, forceAuthn bool, extra ...zap.Field) {
+	fields := idpAggregateLogFields("saml_disco_login_started", "saml", idp)
+	fields = append(fields,
+		zap.String("entry_point", entryPoint),
+		zap.Bool("force_authn", forceAuthn),
+	)
+	fields = append(fields, extra...)
+	h.getLogger().Info("saml login started", fields...)
+}
+
+func (h *DiscoveryHandler) logIdPSelected(idp *domain.IdPInfo, entryPoint string, extra ...zap.Field) {
+	fields := idpAggregateLogFields("saml_disco_idp_selected", "saml", idp)
+	fields = append(fields, zap.String("entry_point", entryPoint))
+	fields = append(fields, extra...)
+	h.getLogger().Info("saml idp selected", fields...)
+}
+
+func (h *DiscoveryHandler) logSessionCreated(authFlow string, idp *domain.IdPInfo) {
+	h.getLogger().Info("saml disco session created", idpAggregateLogFields("saml_disco_session_created", authFlow, idp)...)
 }
 
 // effectivePasscode returns the passcode that gates the given no-authentication
@@ -332,10 +373,6 @@ func (h *DiscoveryHandler) handleBypassIdP(w http.ResponseWriter, r *http.Reques
 		return h.writeInvalidPasscode(w)
 	}
 
-	h.getLogger().Info("bypass idp selected, creating guest session",
-		zap.String("entity_id", idp.EntityID),
-	)
-
 	relayState := returnURL
 	if relayState == "" {
 		relayState = "/"
@@ -358,6 +395,7 @@ func (h *DiscoveryHandler) handleBypassIdP(w http.ResponseWriter, r *http.Reques
 		h.renderAppError(w, r, domain.ServiceError("Failed to create session"))
 		return err
 	}
+	h.logSessionCreated("bypass", idp)
 
 	h.setSessionCookie(w, r, token)
 
@@ -377,8 +415,6 @@ func (h *DiscoveryHandler) handleGuestAccess(w http.ResponseWriter, r *http.Requ
 		h.getLogger().Info("guest access rejected: invalid passcode")
 		return h.writeInvalidPasscode(w)
 	}
-
-	h.getLogger().Info("guest access selected, creating guest session")
 
 	relayState := returnURL
 	if relayState == "" {
@@ -402,6 +438,7 @@ func (h *DiscoveryHandler) handleGuestAccess(w http.ResponseWriter, r *http.Requ
 		h.renderAppError(w, r, domain.ServiceError("Failed to create session"))
 		return err
 	}
+	h.logSessionCreated("guest", &domain.IdPInfo{EntityID: GuestEntityID, DisplayName: h.Config.GuestAccessLabel})
 
 	h.setSessionCookie(w, r, token)
 

--- a/internal/discovery/structured_logging_test.go
+++ b/internal/discovery/structured_logging_test.go
@@ -1,0 +1,146 @@
+//go:build unit
+
+package discovery
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/philiph/caddy-saml-disco/internal/domain"
+	"github.com/philiph/caddy-saml-disco/internal/metadata"
+	"github.com/philiph/caddy-saml-disco/internal/testutil/tra"
+)
+
+type stubAuthStarter struct{}
+
+func (stubAuthStarter) StartAuthWithOptions(_ *domain.IdPInfo, _ *url.URL, _ string, _ *domain.AuthnOptions) (*url.URL, error) {
+	return url.Parse("https://idp.example.edu/sso?SAMLRequest=test")
+}
+
+func TestSelectIdPLogsAggregateSafeSAMLStart(t *testing.T) {
+	tra.Require(t, "Adapter.SAMLOrgEntryLogging")
+
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	entityID := "https://idp.example.edu/idp/shibboleth"
+	h := &DiscoveryHandler{
+		MetadataStore: metadata.NewInMemoryMetadataStore([]domain.IdPInfo{
+			{
+				EntityID:              entityID,
+				DisplayName:           "Example University",
+				RegistrationAuthority: "https://federation.example.org",
+				SSOURL:                "https://idp.example.edu/sso",
+			},
+		}),
+		SAMLService: stubAuthStarter{},
+		Logger:      logger,
+		Config: Config{
+			ForceAuthnPaths: []string{"/secure/*"},
+		},
+	}
+
+	body := `{"entity_id":"` + entityID + `","return_url":"/secure/page","remember":true}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/saml/api/select", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if err := h.HandleSelectIdP(rec, req); err != nil {
+		t.Fatalf("HandleSelectIdP: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	selectedEntries := logs.FilterMessage("saml idp selected").All()
+	if len(selectedEntries) != 1 {
+		t.Fatalf("saml idp selected logs = %d, want 1", len(selectedEntries))
+	}
+	selectedFields := selectedEntries[0].ContextMap()
+	t.Logf("observed aggregate selected log fields: %#v", selectedFields)
+	assertField(t, selectedFields, "event", "saml_disco_idp_selected")
+	assertField(t, selectedFields, "auth_flow", "saml")
+	assertField(t, selectedFields, "idp_entity_id", entityID)
+	assertField(t, selectedFields, "idp_display_name", "Example University")
+	assertField(t, selectedFields, "idp_registration_authority", "https://federation.example.org")
+	assertField(t, selectedFields, "entry_point", "api_select")
+	assertField(t, selectedFields, "remember_idp", true)
+	assertAbsentField(t, selectedFields, "subject")
+
+	entries := logs.FilterMessage("saml login started").All()
+	if len(entries) != 1 {
+		t.Fatalf("saml login started logs = %d, want 1", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	t.Logf("observed aggregate log fields: %#v", fields)
+	assertField(t, fields, "event", "saml_disco_login_started")
+	assertField(t, fields, "auth_flow", "saml")
+	assertField(t, fields, "idp_entity_id", entityID)
+	assertField(t, fields, "idp_display_name", "Example University")
+	assertField(t, fields, "idp_registration_authority", "https://federation.example.org")
+	assertField(t, fields, "entry_point", "api_select")
+	assertField(t, fields, "force_authn", true)
+	assertField(t, fields, "remember_idp", true)
+	assertAbsentField(t, fields, "subject")
+}
+
+func TestSelectIdPLogsAggregateSafeNoAuthSessionEvents(t *testing.T) {
+	tra.Require(t, "Adapter.SAMLOrgEntryLogging")
+
+	core, logs := observer.New(zap.InfoLevel)
+	h := newPasscodeHandler(t, "")
+	h.Logger = zap.New(core)
+	h.Config.SessionDuration = time.Hour
+
+	for _, entityID := range []string{bypassEntityID, GuestEntityID} {
+		body := `{"entity_id":"` + entityID + `","return_url":"` + testReturnURL + `"}`
+		rec := postSelect(t, h, body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("entity %s status = %d, want %d (body: %s)", entityID, rec.Code, http.StatusOK, rec.Body.String())
+		}
+	}
+
+	entries := logs.FilterMessage("saml disco session created").All()
+	if len(entries) != 2 {
+		t.Fatalf("session-created logs = %d, want 2", len(entries))
+	}
+	byFlow := map[string]map[string]interface{}{}
+	for _, entry := range entries {
+		fields := entry.ContextMap()
+		t.Logf("observed aggregate session log fields: %#v", fields)
+		flow, ok := fields["auth_flow"].(string)
+		if !ok || flow == "" {
+			t.Fatalf("auth_flow field missing or non-string: %#v", fields["auth_flow"])
+		}
+		byFlow[flow] = fields
+		assertField(t, fields, "event", "saml_disco_session_created")
+		assertAbsentField(t, fields, "subject")
+	}
+
+	assertField(t, byFlow["bypass"], "idp_entity_id", bypassEntityID)
+	assertField(t, byFlow["bypass"], "idp_display_name", "Uni Tübingen")
+	assertField(t, byFlow["guest"], "idp_entity_id", GuestEntityID)
+	assertField(t, byFlow["guest"], "idp_display_name", "Rechtsberatung")
+}
+
+func assertField(t *testing.T, fields map[string]interface{}, key string, want interface{}) {
+	t.Helper()
+	if fields == nil {
+		t.Fatalf("fields map is nil while checking %s", key)
+	}
+	if got := fields[key]; got != want {
+		t.Fatalf("field %s = %#v, want %#v (all fields: %#v)", key, got, want, fields)
+	}
+}
+
+func assertAbsentField(t *testing.T, fields map[string]interface{}, key string) {
+	t.Helper()
+	if _, ok := fields[key]; ok {
+		t.Fatalf("field %s should be absent (all fields: %#v)", key, fields)
+	}
+}


### PR DESCRIPTION
Adds aggregate-safe Caddy-SAML-Disco logs for WAYF IdP selections so downstream Loki analytics can count Heidelberg vs Mannheim clicks without exposing user identifiers, cookies, passcodes, assertions, or attributes.\n\nVerification:\n- gofmt on changed files\n- go test -tags unit ./internal/discovery ./internal/authentication\n- go test ./...\n- GPT-5.5 final review: SHIPBAR