### PR TITLE
fix(auth): return JSON for expired API sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.4] - 2026-06-26
+
+### Fixed
+- API/fetch requests with an expired or missing SAML session now receive explicit JSON 401 responses instead of browser redirects.
+
 ## [0.21.2] - 2026-06-17
 
 ### Fixed

--- a/internal/caddy/handler_endpoints_test.go
+++ b/internal/caddy/handler_endpoints_test.go
@@ -122,6 +122,76 @@ func TestServeHTTP_PreservesOriginalURL(t *testing.T) {
 	}
 }
 
+func TestServeHTTP_APIRequestWithoutSession_ReturnsJSONUnauthorized(t *testing.T) {
+	key := loadTestKey(t)
+	cert, err := session.LoadCertificate("../../testdata/sp-cert.pem")
+	if err != nil {
+		t.Fatalf("load certificate: %v", err)
+	}
+
+	store := session.NewCookieSessionStore(key, 8*time.Hour)
+	samlService := NewSAMLService("https://sp.example.com", key, cert)
+	metadataStore := &mockMetadataStore{
+		idps: []domain.IdPInfo{{
+			EntityID:   "https://idp.example.com/saml",
+			SSOURL:     "https://idp.example.com/saml/sso",
+			SSOBinding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+		}},
+	}
+
+	s := &SAMLDisco{
+		Config: Config{
+			EntityID:          "https://sp.example.com",
+			SessionCookieName: "saml_session",
+		},
+	}
+	s.SetSessionStore(store)
+	s.SetSAMLService(samlService)
+	s.SetMetadataStore(metadataStore)
+
+	req := httptest.NewRequest(http.MethodPost, "/transcription/check_transcription_exists", strings.NewReader("[]"))
+	req.Host = "sp.example.com"
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Referer", "https://sp.example.com/chat?job=123")
+	rec := httptest.NewRecorder()
+	next := &mockNextHandler{}
+
+	err = s.ServeHTTP(rec, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP returned error: %v", err)
+	}
+	if next.called {
+		t.Fatal("downstream handler should not be called without a valid session")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body=%q", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+	if location := rec.Header().Get("Location"); location != "" {
+		t.Fatalf("Location = %q, want empty JSON response", location)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	if got := rec.Header().Get("X-SAML-Session-Expired"); got != "1" {
+		t.Fatalf("X-SAML-Session-Expired = %q, want 1", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode JSON body: %v; body=%q", err, rec.Body.String())
+	}
+	if payload["error"] != "session_expired" {
+		t.Errorf("error = %q, want session_expired", payload["error"])
+	}
+	if payload["login_url"] != "/saml/disco?return_url=%2Fchat%3Fjob%3D123" {
+		t.Errorf("login_url = %q", payload["login_url"])
+	}
+}
+
 // TestServeHTTP_SessionInContext verifies that a valid session is stored in
 // the request context for downstream handlers to access.
 

--- a/internal/caddy/request_handler.go
+++ b/internal/caddy/request_handler.go
@@ -83,12 +83,18 @@ func (s *SAMLDisco) serveDownstream(w http.ResponseWriter, r *http.Request, next
 	}
 	cookie, err := r.Cookie(spConfig.Config.SessionCookieName)
 	if err != nil || cookie.Value == "" {
+		if s.answerSessionExpiredJSON(w, r, spConfig) {
+			return nil
+		}
 		s.redirectToIdPInternal(w, r, spConfig)
 		return nil
 	}
 	session, err := spConfig.sessionStore.Get(cookie.Value)
 	if err != nil {
 		s.getMetricsRecorder().RecordSessionValidation(false)
+		if s.answerSessionExpiredJSON(w, r, spConfig) {
+			return nil
+		}
 		s.redirectToIdPInternal(w, r, spConfig)
 		return nil
 	}

--- a/internal/caddy/session_expired.go
+++ b/internal/caddy/session_expired.go
@@ -1,0 +1,79 @@
+package caddy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/philiph/caddy-saml-disco/internal/httputil"
+)
+
+type sessionExpiredJSONResponse struct {
+	Error    string `json:"error"`
+	LoginURL string `json:"login_url"`
+}
+
+func (s *SAMLDisco) answerSessionExpiredJSON(w http.ResponseWriter, r *http.Request, spConfig *SPConfig) bool {
+	if !wantsJSONAuthFailure(r) {
+		return false
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-SAML-Session-Expired", "1")
+	if spConfig != nil {
+		httputil.ClearSessionCookieWithConfig(w, r, &spCookieConfig{sp: spConfig})
+	}
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(sessionExpiredJSONResponse{
+		Error:    "session_expired",
+		LoginURL: sessionExpiredLoginURL(r),
+	})
+	return true
+}
+
+func wantsJSONAuthFailure(r *http.Request) bool {
+	accept := strings.ToLower(r.Header.Get("Accept"))
+	if strings.Contains(accept, "application/json") {
+		return true
+	}
+
+	contentType := strings.ToLower(r.Header.Get("Content-Type"))
+	if strings.Contains(contentType, "application/json") {
+		return true
+	}
+
+	if strings.EqualFold(r.Header.Get("X-Requested-With"), "XMLHttpRequest") {
+		return true
+	}
+
+	fetchMode := strings.ToLower(r.Header.Get("Sec-Fetch-Mode"))
+	return fetchMode != "" && fetchMode != "navigate"
+}
+
+func sessionExpiredLoginURL(r *http.Request) string {
+	return "/saml/disco?return_url=" + url.QueryEscape(sessionExpiredReturnURL(r))
+}
+
+func sessionExpiredReturnURL(r *http.Request) string {
+	if ref := r.Header.Get("Referer"); ref != "" {
+		if returnURL := sameHostRelativeURL(ref, r.Host); returnURL != "" {
+			return returnURL
+		}
+	}
+	return "/"
+}
+
+func sameHostRelativeURL(rawURL, host string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host != host || parsed.Path == "" || strings.HasPrefix(parsed.Path, "/saml/") {
+		return ""
+	}
+
+	relative := parsed.RequestURI()
+	if parsed.Fragment != "" {
+		relative += "#" + parsed.Fragment
+	}
+	return httputil.ValidateRelayState(relative)
+}


### PR DESCRIPTION
## Summary
- Return explicit JSON 401 responses for API/fetch requests when the SAML session is missing or invalid.
- Include `X-SAML-Session-Expired: 1`, `Cache-Control: no-store`, a safe `login_url`, and clear the stale session cookie.
- Keep browser navigations on the existing redirect-to-IdP/discovery path.

## Verification
- `go test -tags unit ./internal/caddy -run 'TestServeHTTP_APIRequestWithoutSession_ReturnsJSONUnauthorized|TestServeHTTP_PreservesOriginalURL' -count=1`
- `go test -tags unit ./internal/caddy -count=1`
- `go test ./...`

Pre-commit review: GPT-5.5 final verdict minor/no blockers; addressed CoreService ordering/origin suggestions on the paired frontend MR.
